### PR TITLE
Fix typos : replace "num" with "npm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Building and Using Beta Versions
 
 * run `npm install`
 
-* run `num run group` or `num run groupFirefox` or `num run groupChrome` or `num run groupSafari` or `num run groupWebext`
+* run `npm run group` or `npm run groupFirefox` or `npm run groupChrome` or `npm run groupSafari` or `npm run groupWebext`
 
-* run `num run group:debug` or `num run groupFirefox:debug` or `num run groupChrome:debug` or `num run groupSafari:debug` or `num run groupWebext:debug` to keep all debug statements and comments.
+* run `npm run group:debug` or `npm run groupFirefox:debug` or `npm run groupChrome:debug` or `npm run groupSafari:debug` or `npm run groupWebext:debug` to keep all debug statements and comments.
 
 * for chrome, load the unpacked extension from the Build/Chrome folder
 


### PR DESCRIPTION
I identified a typo in the "Building and Using Beta Versions" section of the `README.md` file. The installation commands were incorrectly listed as `num run ...` instead of the standard `npm run ...`.

Replaced multiple instances of `num` with `npm` in the installation instructions.

New contributors trying to set up the project locally might get confused or face errors if they copy paste the incorrect commands. Fixing this ensures the documentation is accurate and beginner friendly.

I verified that `npm` is the correct Node Package Manager command. I checked the surrounding text to ensure no other commands were affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed incorrect command examples in README to use correct npm syntax.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->